### PR TITLE
fix: valid var never set to false

### DIFF
--- a/main.go
+++ b/main.go
@@ -117,6 +117,7 @@ func (ranker *Ranker) AdjustBatchSize(objects []Object, samples int) {
 				if estBatchTokens > ranker.cfg.TokenLimit {
 					log.Printf("Sample %d: estimated tokens %d > max token threshold %d", i, estBatchTokens, ranker.cfg.TokenLimit)
 					ranker.logTokenSizes(batch)
+					valid = false
 					break
 				}
 			}


### PR DESCRIPTION
First of, thanks for this! Very interesting project, played around a bit and I think I got a lil bug if I understand correctly

Fix AdjustBatchSize bug: Previously, batches that exceeded the token limit weren't marked as invalid because the 'valid' flag was never set to false. 
```
go run main.go -f testdata/sentences.txt -r 10 -s 5 -t 210 -p 'Rank each of these items according to their relevancy to the concept of "time".' -ollama-model llama3.2
2025/02/27 20:59:49 Sample 0: estimated tokens 273 > max token threshold 199
2025/02/27 20:59:49 Logging token sizes for each object in the batch:
2025/02/27 20:59:49 Object ID: US79698O, Token Size: 192, Value Preview: He spotted a shooting star while stargazing.
2025/02/27 20:59:49 Object ID: nJsA4h_z, Token Size: 193, Value Preview: The ship's horn sounded as it departed the dock.
2025/02/27 20:59:49 Object ID: EklQjbYW, Token Size: 195, Value Preview: She climbed to the top of the hill to watch the sunset.
2025/02/27 20:59:49 Object ID: sNhFh5LH, Token Size: 193, Value Preview: He read the letter aloud with a trembling voice.
2025/02/27 20:59:49 Object ID: P1DZBubT, Token Size: 192, Value Preview: The chef drizzled sauce over the plated dish.
2025/02/27 20:59:49 Average estimated tokens: 1 (0.48% of max 210 tokens)
2025/02/27 20:59:49 Decreasing batch size to 4
```