### PR TITLE
new: -json cli flag forces reading input as json

### DIFF
--- a/main.go
+++ b/main.go
@@ -196,7 +196,7 @@ func ShortDeterministicID(input string, length int) string {
 	return base64Encoded[:length]
 }
 
-func loadObjectsFromFile(filePath string, templateData string) (objects []Object, err error) {
+func loadObjectsFromFile(filePath string, templateData string, forceJSON bool) (objects []Object, err error) {
 	var tmpl *template.Template
 	if templateData != "" {
 		if templateData[0] == '@' {
@@ -218,7 +218,7 @@ func loadObjectsFromFile(filePath string, templateData string) (objects []Object
 	defer file.Close()
 
 	ext := strings.ToLower(filepath.Ext(filePath))
-	if ext == ".json" {
+	if ext == ".json" || forceJSON {
 		// parse the file in an opaque array
 		var data []interface{}
 		if err := json.NewDecoder(file).Decode(&data); err != nil {
@@ -280,6 +280,7 @@ func main() {
 	log.SetOutput(os.Stderr)
 
 	inputFile := flag.String("f", "", "Input file")
+	forceJSON := flag.Bool("json", false, "Force JSON parsing regardless of file extension")
 	inputTemplate := flag.String("template", "{{.Data}}", "Template for each object in the input file (prefix with @ to use a file)")
 	batchSize := flag.Int("s", 10, "Number of items per batch")
 	numRuns := flag.Int("r", 10, "Number of runs")
@@ -348,7 +349,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	objects, err := loadObjectsFromFile(*inputFile, *inputTemplate)
+	objects, err := loadObjectsFromFile(*inputFile, *inputTemplate, *forceJSON)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
New `-json` CLI flag allows reading input as JSON even without `.json` file extension.

Before the change: Using some simple JSON test data, Raink works fine with `.json` file extension, but not from stdin.

```
seq 9 |
    paste -d '@' - - - |
    parallel 'echo {} | tr @ "\n" | jo -a | jo vals=:/dev/stdin' |
    jo -a |
    tee /dev/stderr \
        >input.json

[{"vals":[1,2,3]},{"vals":[4,5,6]},{"vals":[7,8,9]}]

go run main.go -f input.json -p 'Which is biggest?' -template '{{ index .vals 0 }}' -r 1 | jq -c '.[]'
{"key":"eQJpm-Qs","value":"7","object":{"vals":[7,8,9]},"score":0,"exposure":1,"rank":1}
{"key":"SyJ3d9Td","value":"4","object":{"vals":[4,5,6]},"score":2,"exposure":1,"rank":2}
{"key":"a4ayc_80","value":"1","object":{"vals":[1,2,3]},"score":3,"exposure":1,"rank":3}

cat input.json | go run main.go -f /dev/stdin -p 'Which is biggest?' -template '{{ index .vals 0 }}' -r 1 | jq -c '.[]'
2025/03/01 08:59:23 template: raink-item-template:1:3: executing "raink-item-template" at <index .vals 0>: error calling index: index of untyped nil
exit status 1
```

After the change: Providing new `-json` flag forces interpretation of input as JSON.

```
cat input.json | go run main.go -json -f /dev/stdin -p 'Which is biggest?' -template '{{ index .vals 0 }}' -r 1 | jq -c '.[]'
{"key":"eQJpm-Qs","value":"7","object":{"vals":[7,8,9]},"score":0,"exposure":1,"rank":1}
{"key":"SyJ3d9Td","value":"4","object":{"vals":[4,5,6]},"score":2,"exposure":1,"rank":2}
{"key":"a4ayc_80","value":"1","object":{"vals":[1,2,3]},"score":3,"exposure":1,"rank":3}
