### PR TITLE
Simpler short ids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 raink
+trace-*.json
+raink-*.json

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Usage of raink:
     	Max tokens per batch (default 128000)
   -template string
     	Template for each object in the input file (prefix with @ to use a file) (default "{{.Data}}")
+  -trace string
+    	Write ranking snapshots to file
 ```
 
 Compares 100 [sentences](https://github.com/noperator/raink/blob/main/testdata/sentences.txt) in under 2 min.
@@ -182,6 +184,7 @@ raink \
 - [ ] add python bindings?
 - [ ] clarify when prompt included in token estimate
 - [ ] remove token limit threshold? potentially confusing/unnecessary
+- [ ] print stats: requests sent, tokens used, time taken, money spent
 
 ### License
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bishopfox/raink
+module github.com/noperator/raink
 
 go 1.23.4
 

--- a/main.go
+++ b/main.go
@@ -257,17 +257,20 @@ func GenerateSchema[T any]() interface{} {
 var RankedObjectResponseSchema = GenerateSchema[RankedObjectResponse]()
 
 func ShortDeterministicID(input string, length int) string {
-	// Step 1: Hash the input using SHA-256
+	// Keep only A-Za-z0-9 from Base64-encoded SHA-256 hash.
 	hash := sha256.Sum256([]byte(input))
-
-	// Step 2: Encode the hash in Base64 (URL-safe)
 	base64Encoded := base64.URLEncoding.EncodeToString(hash[:])
-
-	// Step 3: Truncate to the desired length
-	if length > len(base64Encoded) {
-		length = len(base64Encoded)
+	var result strings.Builder
+	for _, char := range base64Encoded {
+		if (char >= '0' && char <= '9') || (char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') {
+			result.WriteRune(char)
+		}
 	}
-	return base64Encoded[:length]
+	filtered := result.String()
+	if length > len(filtered) {
+		length = len(filtered)
+	}
+	return filtered[:length]
 }
 
 func loadObjectsFromFile(filePath string, templateData string, forceJSON bool) (objects []Object, err error) {


### PR DESCRIPTION
Small-ish LMs will often struggle to correctly reproduce short IDs containing non-alphanumeric characters like `-` and `_` (see example below), so let's remove those characters.

```
2025/04/30 14:10:28 Round 1, Run  4/10, Batch 10/10: Missing IDs: [Dhfayl8-]
2025/04/30 14:10:28 OpenAI API response: {
  "objects": ["KdsMZ4Lb", "i5QL5_t4", "bkABhxwM", "AtILvX45", "Dhfayl8-.", "9co490ih", "yDdknM5D", "hSeokeIk", "5_bAEXdu", "a4ayc_80"]
}
```