### PR TITLE
refact: separate cmd and pkg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-raink
+/raink

--- a/README.md
+++ b/README.md
@@ -175,9 +175,9 @@ raink \
 - [x] add parameter for refinement ratio
 - [x] add blog link
 - [x] support non-OpenAI models
-- [ ] add ~boolean~ refinement ratio flag
+- [x] add ~boolean~ refinement ratio flag
 - [x] separate package and cli tool
-- [ ] add python bindings?
+- [ ] ~~add python bindings?~~
 - [ ] clarify when prompt included in token estimate
 - [ ] remove token limit threshold? potentially confusing/unnecessary
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,7 @@ We built raink to circumvent those issues and solve general ranking problems tha
 ### Install
 
 ```
-git clone https://github.com/noperator/raink
-cd raink
-go install
+go install github.com/noperator/raink/cmd/raink@latest
 ```
 
 ### Configure
@@ -178,7 +176,7 @@ raink \
 - [x] add blog link
 - [x] support non-OpenAI models
 - [ ] add ~boolean~ refinement ratio flag
-- [ ] separate package and cli tool
+- [x] separate package and cli tool
 - [ ] add python bindings?
 - [ ] clarify when prompt included in token estimate
 - [ ] remove token limit threshold? potentially confusing/unnecessary

--- a/cmd/raink/main.go
+++ b/cmd/raink/main.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/noperator/raink/pkg/raink"
+	"github.com/openai/openai-go"
+)
+
+func main() {
+	log.SetOutput(os.Stderr)
+
+	inputFile := flag.String("f", "", "Input file")
+	forceJSON := flag.Bool("json", false, "Force JSON parsing regardless of file extension")
+	inputTemplate := flag.String("template", "{{.Data}}", "Template for each object in the input file (prefix with @ to use a file)")
+	batchSize := flag.Int("s", 10, "Number of items per batch")
+	numRuns := flag.Int("r", 10, "Number of runs")
+	batchTokens := flag.Int("t", 128000, "Max tokens per batch")
+	initialPrompt := flag.String("p", "", "Initial prompt (prefix with @ to use a file)")
+	outputFile := flag.String("o", "", "JSON output file")
+
+	ollamaURL := flag.String("ollama-url", "http://localhost:11434/api/chat", "Ollama API URL")
+	ollamaModel := flag.String("ollama-model", "", "Ollama model name (if not set, OpenAI will be used)")
+	oaiModel := flag.String("openai-model", openai.ChatModelGPT4oMini, "OpenAI model name")
+	oaiURL := flag.String("openai-url", "", "OpenAI API base URL (e.g., for OpenAI-compatible API like vLLM)")
+	encoding := flag.String("encoding", "o200k_base", "Tokenizer encoding")
+
+	dryRun := flag.Bool("dry-run", false, "Enable dry run mode (log API calls without making them)")
+	refinementRatio := flag.Float64("ratio", 0.5, "Refinement ratio as a decimal (e.g., 0.5 for 50%)")
+	flag.Parse()
+
+	// This is a heuristic to detect if the user set a custom batch token limit for Ollama
+	if *ollamaModel != "" && *batchTokens == 128000 {
+		*batchTokens = 4096
+	}
+
+	// This "threshold" is a way to add some padding to our estimation of
+	// average token usage per batch. We're effectively leaving 5% of
+	// wiggle room.
+	var tokenLimitThreshold = int(0.95 * float64(*batchTokens))
+
+	if *inputFile == "" {
+		log.Println("Usage: raink -f <input_file> [-s <batch_size>] [-r <num_runs>] [-p <initial_prompt>] [-t <batch_tokens>] [-ollama-model <model_name>] [-openai-model <model_name>] [-openai-url <base_url>] [-ratio <refinement_ratio>]")
+		return
+	}
+
+	if *refinementRatio < 0 || *refinementRatio >= 1 {
+		fmt.Println("Error: Refinement ratio must be >= 0 and < 1")
+		os.Exit(1)
+	}
+
+	userPrompt := *initialPrompt
+	if strings.HasPrefix(userPrompt, "@") {
+		filePath := strings.TrimPrefix(userPrompt, "@")
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			log.Fatalf("Error reading initial prompt file: %v", err)
+		}
+		userPrompt = string(content)
+	}
+
+	config := &raink.Config{
+		InitialPrompt:   userPrompt,
+		BatchSize:       *batchSize,
+		NumRuns:         *numRuns,
+		OllamaModel:     *ollamaModel,
+		OpenAIModel:     *oaiModel,
+		TokenLimit:      tokenLimitThreshold,
+		RefinementRatio: *refinementRatio,
+		OpenAIKey:       os.Getenv("OPENAI_API_KEY"),
+		OpenAIAPIURL:    *oaiURL,
+		OllamaAPIURL:    *ollamaURL,
+		Encoding:        *encoding,
+		BatchTokens:     *batchTokens,
+		DryRun:          *dryRun,
+	}
+
+	ranker, err := raink.NewRanker(config)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	objects, err := raink.LoadObjectsFromFile(*inputFile, *inputTemplate, *forceJSON)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// check that no object is too large
+	for _, obj := range objects {
+		tokens := ranker.EstimateTokens([]raink.Object{obj}, true)
+		if tokens > *batchTokens {
+			log.Fatalf("Object is too large with %d tokens:\n%s", tokens, obj.Value)
+		}
+	}
+
+	// Dynamically adjust batch size upfront.
+	ranker.AdjustBatchSize(objects, 10)
+
+	// Recursive processing
+	finalResults := ranker.Rank(objects, 1)
+
+	// Add the rank key to each final result based on its position in the list
+	for i := range finalResults {
+		finalResults[i].Rank = i + 1
+	}
+
+	jsonResults, err := json.MarshalIndent(finalResults, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+
+	if !config.DryRun {
+		fmt.Println(string(jsonResults))
+	}
+
+	if *outputFile != "" {
+		os.WriteFile(*outputFile, jsonResults, 0644)
+		log.Printf("Results written to %s\n", *outputFile)
+	}
+}

--- a/cmd/raink/main.go
+++ b/cmd/raink/main.go
@@ -85,30 +85,9 @@ func main() {
 		log.Fatal(err)
 	}
 
-	objects, err := raink.LoadObjectsFromFile(*inputFile, *inputTemplate, *forceJSON)
+	finalResults, err := ranker.RankFromFile(*inputFile, *inputTemplate, *forceJSON)
 	if err != nil {
 		log.Fatal(err)
-	}
-
-	// check that no object is too large
-	for _, obj := range objects {
-		tokens := ranker.EstimateTokens([]raink.Object{obj}, true)
-		if tokens > *batchTokens {
-			log.Fatalf("object is too large with %d tokens:\n%s", tokens, obj.Value)
-		}
-	}
-
-	// Dynamically adjust batch size upfront.
-	if err := ranker.AdjustBatchSize(objects, 10); err != nil {
-		log.Fatal(err)
-	}
-
-	// Recursive processing
-	finalResults := ranker.Rank(objects, 1)
-
-	// Add the rank key to each final result based on its position in the list
-	for i := range finalResults {
-		finalResults[i].Rank = i + 1
 	}
 
 	jsonResults, err := json.MarshalIndent(finalResults, "", "  ")

--- a/cmd/raink/main.go
+++ b/cmd/raink/main.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"strings"
 
@@ -13,8 +13,6 @@ import (
 )
 
 func main() {
-	log.SetOutput(os.Stderr)
-
 	inputFile := flag.String("f", "", "Input file")
 	forceJSON := flag.Bool("json", false, "Force JSON parsing regardless of file extension")
 	inputTemplate := flag.String("template", "{{.Data}}", "Template for each object in the input file (prefix with @ to use a file)")
@@ -32,7 +30,17 @@ func main() {
 
 	dryRun := flag.Bool("dry-run", false, "Enable dry run mode (log API calls without making them)")
 	refinementRatio := flag.Float64("ratio", 0.5, "Refinement ratio as a decimal (e.g., 0.5 for 50%)")
+	debug := flag.Bool("debug", false, "Enable debug logging")
 	flag.Parse()
+
+	// Set up structured logging with level based on debug flag
+	logLevel := slog.LevelInfo
+	if *debug {
+		logLevel = slog.LevelDebug
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: logLevel,
+	})).With("component", "raink-cli")
 
 	// This is a heuristic to detect if the user set a custom batch token limit for Ollama
 	if *ollamaModel != "" && *batchTokens == 128000 {
@@ -45,7 +53,7 @@ func main() {
 	var tokenLimitThreshold = int(0.95 * float64(*batchTokens))
 
 	if *inputFile == "" {
-		log.Println("Usage: raink -f <input_file> [-s <batch_size>] [-r <num_runs>] [-p <initial_prompt>] [-t <batch_tokens>] [-ollama-model <model_name>] [-openai-model <model_name>] [-openai-url <base_url>] [-ratio <refinement_ratio>]")
+		logger.Error("Usage: raink -f <input_file> [-s <batch_size>] [-r <num_runs>] [-p <initial_prompt>] [-t <batch_tokens>] [-ollama-model <model_name>] [-openai-model <model_name>] [-openai-url <base_url>] [-ratio <refinement_ratio>]")
 		return
 	}
 
@@ -59,7 +67,8 @@ func main() {
 		filePath := strings.TrimPrefix(userPrompt, "@")
 		content, err := os.ReadFile(filePath)
 		if err != nil {
-			log.Fatalf("could not read initial prompt file: %v", err)
+			logger.Error("could not read initial prompt file", "error", err)
+			os.Exit(1)
 		}
 		userPrompt = string(content)
 	}
@@ -78,21 +87,25 @@ func main() {
 		Encoding:        *encoding,
 		BatchTokens:     *batchTokens,
 		DryRun:          *dryRun,
+		LogLevel:        logLevel,
 	}
 
 	ranker, err := raink.NewRanker(config)
 	if err != nil {
-		log.Fatal(err)
+		logger.Error("failed to create ranker", "error", err)
+		os.Exit(1)
 	}
 
 	finalResults, err := ranker.RankFromFile(*inputFile, *inputTemplate, *forceJSON)
 	if err != nil {
-		log.Fatal(err)
+		logger.Error("failed to rank from file", "error", err)
+		os.Exit(1)
 	}
 
 	jsonResults, err := json.MarshalIndent(finalResults, "", "  ")
 	if err != nil {
-		log.Fatalf("could not marshal results to JSON: %v", err)
+		logger.Error("could not marshal results to JSON", "error", err)
+		os.Exit(1)
 	}
 
 	if !config.DryRun {
@@ -101,6 +114,6 @@ func main() {
 
 	if *outputFile != "" {
 		os.WriteFile(*outputFile, jsonResults, 0644)
-		log.Printf("results written to %s\n", *outputFile)
+		logger.Info("results written to file", "file", *outputFile)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bishopfox/raink
+module github.com/noperator/raink
 
 go 1.23.4
 

--- a/pkg/raink/raink.go
+++ b/pkg/raink/raink.go
@@ -794,7 +794,7 @@ func (r *Ranker) callOpenAI(prompt string, runNum int, batchNum int, inputIDs ma
 				backoff *= 2
 			}
 		} else {
-			return rankedObjectResponse{}, fmt.Errorf("run %*d/%d, batch %*d/%d: unexpected error: %v", len(strconv.Itoa(r.cfg.NumRuns)), runNum, r.cfg.NumRuns, len(strconv.Itoa(r.numBatches)), batchNum, r.numBatches, err)
+			return rankedObjectResponse{}, fmt.Errorf("run %*d/%d, batch %*d/%d: unexpected error: %w", len(strconv.Itoa(r.cfg.NumRuns)), runNum, r.cfg.NumRuns, len(strconv.Itoa(r.numBatches)), batchNum, r.numBatches, err)
 		}
 	}
 }
@@ -818,12 +818,12 @@ func (r *Ranker) callOllama(prompt string, runNum int, batchNum int, inputIDs ma
 			"messages": conversationHistory,
 		})
 		if err != nil {
-			return rankedObjectResponse{}, fmt.Errorf("error creating Ollama API request body: %v", err)
+			return rankedObjectResponse{}, fmt.Errorf("error creating Ollama API request body: %w", err)
 		}
 
 		req, err := http.NewRequest("POST", r.cfg.OllamaAPIURL, bytes.NewReader(requestBody))
 		if err != nil {
-			return rankedObjectResponse{}, fmt.Errorf("error creating Ollama API request: %v", err)
+			return rankedObjectResponse{}, fmt.Errorf("error creating Ollama API request: %w", err)
 		}
 		req.Header.Set("Content-Type", "application/json")
 
@@ -831,7 +831,7 @@ func (r *Ranker) callOllama(prompt string, runNum int, batchNum int, inputIDs ma
 
 		resp, err := client.Do(req)
 		if err != nil {
-			return rankedObjectResponse{}, fmt.Errorf("error making request to Ollama API: %v", err)
+			return rankedObjectResponse{}, fmt.Errorf("error making request to Ollama API: %w", err)
 		}
 		defer resp.Body.Close()
 
@@ -842,7 +842,7 @@ func (r *Ranker) callOllama(prompt string, runNum int, batchNum int, inputIDs ma
 
 		responseBody, err := io.ReadAll(resp.Body)
 		if err != nil {
-			return rankedObjectResponse{}, fmt.Errorf("error reading Ollama API response body: %v", err)
+			return rankedObjectResponse{}, fmt.Errorf("error reading Ollama API response body: %w", err)
 		}
 
 		var ollamaResponse struct {
@@ -853,7 +853,7 @@ func (r *Ranker) callOllama(prompt string, runNum int, batchNum int, inputIDs ma
 
 		err = json.Unmarshal(responseBody, &ollamaResponse)
 		if err != nil {
-			return rankedObjectResponse{}, fmt.Errorf("error parsing Ollama API response: %v", err)
+			return rankedObjectResponse{}, fmt.Errorf("error parsing Ollama API response: %w", err)
 		}
 
 		conversationHistory = append(

--- a/pkg/raink/raink_test.go
+++ b/pkg/raink/raink_test.go
@@ -1,0 +1,306 @@
+package raink
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/openai/openai-go"
+)
+
+func TestNewRanker(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *Config
+		wantErr bool
+	}{
+		{
+			name: "valid config",
+			config: &Config{
+				InitialPrompt:   "test prompt",
+				BatchSize:       5,
+				NumRuns:         2,
+				OpenAIModel:     openai.ChatModelGPT4oMini,
+				TokenLimit:      1000,
+				RefinementRatio: 0.5,
+				OpenAIKey:       "test-key",
+				Encoding:        "o200k_base",
+				BatchTokens:     2000,
+				DryRun:          true,
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty prompt",
+			config: &Config{
+				InitialPrompt: "",
+				BatchSize:     5,
+				NumRuns:       2,
+				OpenAIModel:   openai.ChatModelGPT4oMini,
+				TokenLimit:    1000,
+				OpenAIKey:     "test-key",
+				Encoding:      "o200k_base",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid batch size",
+			config: &Config{
+				InitialPrompt: "test",
+				BatchSize:     1, // Less than minBatchSize (2)
+				NumRuns:       2,
+				OpenAIModel:   openai.ChatModelGPT4oMini,
+				TokenLimit:    1000,
+				OpenAIKey:     "test-key",
+				Encoding:      "o200k_base",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing OpenAI key",
+			config: &Config{
+				InitialPrompt: "test",
+				BatchSize:     5,
+				NumRuns:       2,
+				OpenAIModel:   openai.ChatModelGPT4oMini,
+				TokenLimit:    1000,
+				OpenAIKey:     "", // Empty key
+				Encoding:      "o200k_base",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ranker, err := NewRanker(tt.config)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("NewRanker() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("NewRanker() unexpected error: %v", err)
+				return
+			}
+			if ranker == nil {
+				t.Errorf("NewRanker() returned nil ranker")
+			}
+		})
+	}
+}
+
+func TestRankFromFile_DryRun(t *testing.T) {
+	// Create a temporary test file
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.txt")
+	content := "apple\nbanana\ncherry"
+	if err := os.WriteFile(testFile, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	config := &Config{
+		InitialPrompt:   "Rank by alphabetical order",
+		BatchSize:       3, // Set to 3 to include all items
+		NumRuns:         1,
+		OpenAIModel:     openai.ChatModelGPT4oMini,
+		TokenLimit:      1000,
+		RefinementRatio: 0.0, // Set to 0.0 to disable refinement and keep all results
+		OpenAIKey:       "test-key",
+		Encoding:        "o200k_base",
+		BatchTokens:     2000,
+		DryRun:          true, // Use dry run to avoid actual API calls
+	}
+
+	ranker, err := NewRanker(config)
+	if err != nil {
+		t.Fatalf("NewRanker() unexpected error: %v", err)
+	}
+
+	results, err := ranker.RankFromFile(testFile, "{{.Data}}", false)
+	if err != nil {
+		t.Errorf("RankFromFile() unexpected error: %v", err)
+		return
+	}
+
+	if len(results) == 0 {
+		t.Error("RankFromFile() returned no results")
+		return
+	}
+
+	// Should get at least 2 results (algorithm may batch/filter items)
+	if len(results) < 2 {
+		t.Errorf("RankFromFile() expected at least 2 results, got %d", len(results))
+		return
+	}
+
+	// Verify all results have required fields
+	for i, result := range results {
+		if result.Key == "" {
+			t.Errorf("Result %d missing Key", i)
+		}
+		if result.Value == "" {
+			t.Errorf("Result %d missing Value", i)
+		}
+		if result.Rank == 0 {
+			t.Errorf("Result %d missing Rank", i)
+		}
+		if result.Exposure == 0 {
+			t.Errorf("Result %d missing Exposure", i)
+		}
+	}
+
+	// Verify ranks are properly assigned (1-based) for the results we got
+	for i, result := range results {
+		expectedRank := i + 1
+		if result.Rank != expectedRank {
+			t.Errorf("Result %d expected rank %d, got %d", i, expectedRank, result.Rank)
+		}
+	}
+}
+
+func TestRankFromFile_WithSentencesData(t *testing.T) {
+	sentencesFile := filepath.Join("..", "..", "testdata", "sentences.txt")
+
+	// Check if the testdata file exists
+	if _, err := os.Stat(sentencesFile); os.IsNotExist(err) {
+		t.Skip("testdata/sentences.txt not found, skipping integration test")
+	}
+
+	config := &Config{
+		InitialPrompt:   `Rank each of these items according to their relevancy to the concept of "time".`,
+		BatchSize:       10,
+		NumRuns:         3,
+		OpenAIModel:     openai.ChatModelGPT4oMini,
+		TokenLimit:      100000,
+		RefinementRatio: 0.5,
+		OpenAIKey:       "test-key", // This would normally come from environment
+		Encoding:        "o200k_base",
+		BatchTokens:     128000,
+		DryRun:          true, // Use dry run to avoid actual API calls
+	}
+
+	// Allow overriding with actual API base URL for integration testing
+	if apiBase := os.Getenv("OPENAI_API_BASE"); apiBase != "" && os.Getenv("OPENAI_API_KEY") != "" {
+		config.OpenAIAPIURL = apiBase
+		config.OpenAIKey = os.Getenv("OPENAI_API_KEY")
+		config.DryRun = false
+	}
+
+	ranker, err := NewRanker(config)
+	if err != nil {
+		t.Fatalf("NewRanker() unexpected error: %v", err)
+	}
+
+	results, err := ranker.RankFromFile(sentencesFile, "{{.Data}}", false)
+	if err != nil {
+		t.Fatalf("RankFromFile() unexpected error: %v", err)
+	}
+
+	// Basic sanity checks
+	if len(results) == 0 {
+		t.Error("RankFromFile() returned no results")
+		return
+	}
+
+	t.Logf("Successfully ranked %d items from sentences.txt", len(results))
+
+	// Print top 10 results
+	maxResults := 10
+	if len(results) < maxResults {
+		maxResults = len(results)
+	}
+
+	t.Log("Top 10 results by relevance to 'time':")
+	for i := 0; i < maxResults; i++ {
+		t.Logf("%d. %s", i+1, results[i].Value)
+	}
+
+	// If this is not a dry run (real API call), validate that at least one time-related
+	// sentence appears in the top 3 results
+	if !config.DryRun {
+		timeRelatedSentences := []string{
+			"The train arrived exactly on time.",
+			"The clock ticked steadily on the wall.",
+			"The old clock chimed twelve times.",
+		}
+
+		top3Results := results
+		if len(results) > 3 {
+			top3Results = results[:3]
+		}
+
+		foundTimeRelated := false
+		for _, result := range top3Results {
+			for _, timeSentence := range timeRelatedSentences {
+				if result.Value == timeSentence {
+					foundTimeRelated = true
+					t.Logf("Found time-related sentence in top 3: %s (rank %d)", result.Value, result.Rank)
+					break
+				}
+			}
+			if foundTimeRelated {
+				break
+			}
+		}
+
+		if !foundTimeRelated {
+			t.Logf("Warning: None of the expected time-related sentences found in top 3")
+			t.Logf("Expected one of: %v", timeRelatedSentences)
+			t.Logf("Got top 3: %v", []string{top3Results[0].Value, top3Results[1].Value, top3Results[2].Value})
+			// Note: This is a warning, not a failure, since AI ranking can vary
+		}
+	}
+
+	// Verify structure of results
+	for i, result := range results[:maxResults] {
+		if result.Key == "" {
+			t.Errorf("Result %d missing Key", i)
+		}
+		if result.Value == "" {
+			t.Errorf("Result %d missing Value", i)
+		}
+		if result.Rank != i+1 {
+			t.Errorf("Result %d expected rank %d, got %d", i, i+1, result.Rank)
+		}
+	}
+}
+
+func TestRankFromFile_Errors(t *testing.T) {
+	config := &Config{
+		InitialPrompt:   "test prompt",
+		BatchSize:       5,
+		NumRuns:         3,
+		OpenAIModel:     openai.ChatModelGPT4oMini,
+		TokenLimit:      1000,
+		RefinementRatio: 0.5,
+		OpenAIKey:       "test-key",
+		Encoding:        "o200k_base",
+		BatchTokens:     2000,
+		DryRun:          true,
+	}
+
+	ranker, err := NewRanker(config)
+	if err != nil {
+		t.Fatalf("NewRanker() unexpected error: %v", err)
+	}
+
+	// Test with non-existent file
+	_, err = ranker.RankFromFile("nonexistent.txt", "{{.Data}}", false)
+	if err == nil {
+		t.Error("RankFromFile() with non-existent file should return error")
+	}
+
+	// Test with invalid template
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.txt")
+	if err := os.WriteFile(testFile, []byte("test"), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	_, err = ranker.RankFromFile(testFile, "{{.InvalidField | badFunc}}", false)
+	if err == nil {
+		t.Error("RankFromFile() with invalid template should return error")
+	}
+}


### PR DESCRIPTION
Simple test works:

```
go run cmd/raink/main.go  \
    -openai-url "$OPENAI_API_BASE" \
    -f testdata/sentences.txt \
    -r 1 \
    -s 10 \
    -p 'Rank each of these items according to their relevancy to the concept of "time".' |
    jq -r '.[:10] | map(.value)[]' |
    nl

     1	The train arrived exactly on time.
     2	The old clock chimed twelve times.
     3	The bell rang, signaling the end of class.
     4	The ship's horn sounded as it departed the dock.
     5	He watched as the leaves fell one by one.
     6	She climbed to the top of the hill to watch the sunset.
     7	The book had a surprising twist at the end.
     8	He finished the marathon despite the pain.
     9	The crowd erupted in cheers at the winning goal.
    10	The train whistle echoed through the valley.
```