### PR TITLE
Use temporary memorable IDs, set reasonable defaults

### DIFF
--- a/cmd/raink/main.go
+++ b/cmd/raink/main.go
@@ -17,7 +17,7 @@ func main() {
 	forceJSON := flag.Bool("json", false, "Force JSON parsing regardless of file extension")
 	inputTemplate := flag.String("template", "{{.Data}}", "Template for each object in the input file (prefix with @ to use a file)")
 	batchSize := flag.Int("s", 10, "Number of items per batch")
-	numRuns := flag.Int("r", 10, "Number of runs")
+	numRuns := flag.Int("r", 3, "Number of runs")
 	batchTokens := flag.Int("t", 128000, "Max tokens per batch")
 	initialPrompt := flag.String("p", "", "Initial prompt (prefix with @ to use a file)")
 	outputFile := flag.String("o", "", "JSON output file")
@@ -29,7 +29,7 @@ func main() {
 	encoding := flag.String("encoding", "o200k_base", "Tokenizer encoding")
 
 	dryRun := flag.Bool("dry-run", false, "Enable dry run mode (log API calls without making them)")
-	refinementRatio := flag.Float64("ratio", 0.5, "Refinement ratio as a decimal (e.g., 0.5 for 50%)")
+	refinementRatio := flag.Float64("ratio", 0.1, "Refinement ratio as a decimal (e.g., 0.5 for 50%)")
 	debug := flag.Bool("debug", false, "Enable debug logging")
 	flag.Parse()
 


### PR DESCRIPTION
As [previously noted](https://github.com/noperator/raink/pull/8#issue-3032123712), LLMs have trouble reproducing completely random strings; sometimes raink will get "stuck" as a model repeatedly tries and fails to return each ranked object's unique identifier. This change introduces temporary "memorable" identifiers that are unique in the scope of a single ranked batch, and discarded after the ranking operation completes. For example, instead of requiring the LLM to return an identifier like "KdsMZ4Lb", it'll instead look something like "wetcat"—much easier to tokenize and recall.

Also, some have remarked that raink feels "too slow" compared to a traditional sorting algorithm (even though raink is O(n) vs quicksort's O(n^2)). I suspect that this is because raink's somewhat aggressive defaults make it operate more slowly for small data sets. To fix this, I set the default run and ratio values for an appropriate configuration for finding a single needle-in-the-haystack; raink now processes testdata/sentences.txt in 15s vs the old 1m32s (84% speed-up for people trying the tool out).